### PR TITLE
Removed usage of std::wstring, everything is converted to utf-8 now

### DIFF
--- a/include/dmusic/Common.h
+++ b/include/dmusic/Common.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <cstring>
+#include <string>
 
 /// Use this macro to initialize struct fields which are expected to be loaded as little endian data
 #define FIELDINIT(s, f, t) {f = DirectMusic::littleEndianRead<t>(data + offsetof(s, f));}
@@ -82,6 +83,27 @@ namespace DirectMusic {
         for (std::size_t i = 0; i < numBytes; i++) {
             ptr[i] = (val & (0xFF << ((numBytes - i - 1) * 8))) >> ((numBytes - i - 1) * 8);
         }
+    }
+
+    /**
+     * Converts a buffer containing windows UTF16-Date (wchar_t on windows) to a UTF-8 compatible string
+     * @param utf16str Buffer with UTF16-data
+     * @param numChars Number of chars to be found in the given buffer
+     * @return UTF8 representation of the input string
+     */
+    inline std::string utf16_to_utf8(const std::uint16_t* utf16str) {
+        std::string ret;
+
+        // FIXME: More like utf16 to ascii. Should replace this with something proper, but this is good enough for now.
+        for(size_t i = 0; utf16str[i] != '\0'; i++) {
+            if(isascii(utf16str[i])) {
+                ret += static_cast<char>(utf16str[i]);
+            } else {
+                ret += u8"\uFFFD"; // Invalid char-sign
+            }
+        }
+
+        return ret;
     }
 
     struct GUID {

--- a/include/dmusic/Forms.h
+++ b/include/dmusic/Forms.h
@@ -9,7 +9,7 @@
 #include "Structs.h"
 
 namespace DirectMusic {
-    typedef std::tuple<std::wstring, std::vector<std::uint16_t>> Chord;
+    typedef std::tuple<std::string, std::vector<std::uint16_t>> Chord;
     Chord readChord(const DirectMusic::Riff::Chunk& chunk);
 
     class ChordEntry {
@@ -72,15 +72,15 @@ namespace DirectMusic {
         const DMUS_IO_REFERENCE& getHeader() const { return m_header; }
         const GUID& getGuid() const { return m_guid; }
         //const FILETIME& getDate() const { return m_date; }
-        const std::wstring getName() const { return m_name; }
-        const std::wstring getFile() const { return m_file; }
-        const std::wstring getCategory() const { return m_category; }
+        const std::string getName() const { return m_name; }
+        const std::string getFile() const { return m_file; }
+        const std::string getCategory() const { return m_category; }
         const DMUS_IO_VERSION& getVersion() const { return m_version; }
 
     private:
         DMUS_IO_REFERENCE m_header;
         GUID m_guid;
-        std::wstring m_name, m_file, m_category;
+        std::string m_name, m_file, m_category;
         DMUS_IO_VERSION m_version;
     };
 

--- a/include/dmusic/PlayingContext.h
+++ b/include/dmusic/PlayingContext.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <queue>
 #include <mutex>
+#include <functional>
 #include "Structs.h"
 #include "InstrumentPlayer.h"
 #include "Enums.h"

--- a/include/dmusic/Tracks.h
+++ b/include/dmusic/Tracks.h
@@ -59,7 +59,7 @@ namespace DirectMusic {
         std::vector<DMUS_IO_COMMAND> m_commands;
     };
 
-    typedef std::tuple<DMUS_IO_LYRICSTRACK_EVENTHEADER, std::wstring> LyricsEvent;
+    typedef std::tuple<DMUS_IO_LYRICSTRACK_EVENTHEADER, std::string> LyricsEvent;
 
     class LyricsTrack
         : public SubtrackForm {

--- a/src/Forms/Chordmap.cpp
+++ b/src/Forms/Chordmap.cpp
@@ -15,7 +15,7 @@ Chord DirectMusic::readChord(const Chunk& c) {
         const std::string& id = subchunk.getId();
         const std::uint8_t *data = subchunk.getData().data();
         if (id == "UNAM") {
-            name = std::string(utf16_to_utf8((uint16_t*)data));
+            name = std::string(utf16_to_utf8((const std::uint16_t*)data));
         } else if (id == "sbcn") {
             const std::uint8_t *start = data;
             while (data - start < subchunk.getData().size()) {

--- a/src/Forms/Chordmap.cpp
+++ b/src/Forms/Chordmap.cpp
@@ -8,14 +8,14 @@ Chord DirectMusic::readChord(const Chunk& c) {
     if (c.getId() != "LIST" || c.getListId() != "chrd")
         throw DirectMusic::InvalidChunkException("LIST chrd", c.getId() + " " + c.getListId());
 
-    std::wstring name;
+    std::string name;
     std::vector<std::uint16_t> indexes;
 
     for (const Chunk& subchunk : c.getSubchunks()) {
         const std::string& id = subchunk.getId();
         const std::uint8_t *data = subchunk.getData().data();
         if (id == "UNAM") {
-            name = std::wstring((const wchar_t *)data);
+            name = std::string(utf16_to_utf8((uint16_t*)data));
         } else if (id == "sbcn") {
             const std::uint8_t *start = data;
             while (data - start < subchunk.getData().size()) {

--- a/src/Forms/ReferenceList.cpp
+++ b/src/Forms/ReferenceList.cpp
@@ -17,11 +17,11 @@ ReferenceList::ReferenceList(const Chunk& c) {
         } else if(id == "date") {
             // Let's ignore it for now...
         } else if(id == "name") {
-            m_name = std::string(utf16_to_utf8((const uint16_t*)subchunk.getData().data()));
+            m_name = std::string(utf16_to_utf8((const std::uint16_t*)subchunk.getData().data()));
         } else if(id == "file") {
-            m_file = std::string(utf16_to_utf8((const uint16_t*)subchunk.getData().data()));
+            m_file = std::string(utf16_to_utf8((const std::uint16_t*)subchunk.getData().data()));
         } else if(id == "catg") {
-            m_category = std::string(utf16_to_utf8((const uint16_t*)subchunk.getData().data()));
+            m_category = std::string(utf16_to_utf8((const std::uint16_t*)subchunk.getData().data()));
         } else if(id == "vers") {
             m_version = DMUS_IO_VERSION(subchunk.getData().data());
         }

--- a/src/Forms/ReferenceList.cpp
+++ b/src/Forms/ReferenceList.cpp
@@ -17,11 +17,11 @@ ReferenceList::ReferenceList(const Chunk& c) {
         } else if(id == "date") {
             // Let's ignore it for now...
         } else if(id == "name") {
-            m_name = std::wstring((const wchar_t *)subchunk.getData().data());
+            m_name = std::string(utf16_to_utf8((const uint16_t*)subchunk.getData().data()));
         } else if(id == "file") {
-            m_file = std::wstring((const wchar_t *)subchunk.getData().data());
+            m_file = std::string(utf16_to_utf8((const uint16_t*)subchunk.getData().data()));
         } else if(id == "catg") {
-            m_category = std::wstring((const wchar_t *)subchunk.getData().data());
+            m_category = std::string(utf16_to_utf8((const uint16_t*)subchunk.getData().data()));
         } else if(id == "vers") {
             m_version = DMUS_IO_VERSION(subchunk.getData().data());
         }

--- a/src/Forms/Tracks.cpp
+++ b/src/Forms/Tracks.cpp
@@ -184,7 +184,7 @@ static LyricsEvent readLyricsEvent(const Chunk& c) {
         if (id == "stmp") {
             header = DMUS_IO_LYRICSTRACK_EVENTHEADER(subchunk.getData().data());
         } else if (id == "lyrn") {
-            return std::make_tuple(header, std::wstring((const wchar_t *)subchunk.getData().data()));
+            return std::make_tuple(header, std::string(utf16_to_utf8((const uint16_t*)subchunk.getData().data())));
         }
     }
 

--- a/src/Forms/Tracks.cpp
+++ b/src/Forms/Tracks.cpp
@@ -184,7 +184,7 @@ static LyricsEvent readLyricsEvent(const Chunk& c) {
         if (id == "stmp") {
             header = DMUS_IO_LYRICSTRACK_EVENTHEADER(subchunk.getData().data());
         } else if (id == "lyrn") {
-            return std::make_tuple(header, std::string(utf16_to_utf8((const uint16_t*)subchunk.getData().data())));
+            return std::make_tuple(header, std::string(utf16_to_utf8((const std::uint16_t*)subchunk.getData().data())));
         }
     }
 

--- a/src/MusicMessages.cpp
+++ b/src/MusicMessages.cpp
@@ -46,10 +46,7 @@ BandChangeMessage::BandChangeMessage(PlayingContext& ctx, std::uint32_t time, co
             std::uint8_t bankLo = (header.dwPatch & 0x0000FF00) >> 0x8;
             std::uint8_t patch = (header.dwPatch & 0x000000FF);
 
-            using convert_type = std::codecvt_utf8<wchar_t>;
-            std::wstring_convert<convert_type, wchar_t> converter;
-            std::string converted_str = converter.to_bytes(ref->getFile());
-            auto dls = ctx.loadInstrumentCollection(converted_str);
+            auto dls = ctx.loadInstrumentCollection(ref->getFile());
             
             assert(dls != nullptr);
             instruments[header.dwPChannel] = createInstrument(ctx, bankLo, bankHi, patch, *dls);

--- a/src/PlayingContext.cpp
+++ b/src/PlayingContext.cpp
@@ -182,7 +182,7 @@ void PlayingContext::playSegment(const SegmentForm& segment/*, DMUS_SEGF_FLAGS f
                 const std::uint16_t timestamp = std::get<0>(style);
                 const ReferenceList refs = std::get<1>(style);
 
-                std::wstring styleFile = refs.getFile();
+                std::string styleFile = refs.getFile();
                 auto styleForm = loadStyle(std::string(styleFile.begin(), styleFile.end()));
                 assert(styleForm != nullptr);
                 m_primarySegment = std::make_unique<Segment>();

--- a/src/Riff.cpp
+++ b/src/Riff.cpp
@@ -88,7 +88,7 @@ Unfo::Unfo(const Chunk& c) {
         std::vector<std::uint8_t> data = subchunk.getData();
         const std::string& id = subchunk.getId();
 
-        std::string value = utf16_to_utf8((const uint16_t *)data.data());
+        std::string value = utf16_to_utf8((const std::uint16_t *)data.data());
         if (id == "UARL") m_iarl = value;
         if (id == "UART") m_iart = value;
         if (id == "UCMS") m_icms = value;

--- a/src/Riff.cpp
+++ b/src/Riff.cpp
@@ -2,6 +2,8 @@
 #include <dmusic/Exceptions.h>
 #include <dmusic/Common.h>
 #include <string>
+#include <codecvt>
+#include <locale>
 
 using namespace DirectMusic::Riff;
 
@@ -85,7 +87,8 @@ Unfo::Unfo(const Chunk& c) {
     for (const Chunk& subchunk : c.getSubchunks()) {
         std::vector<std::uint8_t> data = subchunk.getData();
         const std::string& id = subchunk.getId();
-        std::string value = ucs_to_ascii((std::uint16_t *)data.data());
+
+        std::string value = utf16_to_utf8((const uint16_t *)data.data());
         if (id == "UARL") m_iarl = value;
         if (id == "UART") m_iart = value;
         if (id == "UCMS") m_icms = value;

--- a/utils/dmrender/src/dmrender.cpp
+++ b/utils/dmrender/src/dmrender.cpp
@@ -89,7 +89,7 @@ void printTrack<std::shared_ptr<ChordTrack>>(const std::shared_ptr<ChordTrack>& 
     for (const auto& chord : track->getChords()) {
         const auto& chordHeader = std::get<0>(chord);
         const auto& subchords = std::get<1>(chord);
-        std::cout << std::string((const wchar_t *)chordHeader.wszName) << "\n";
+        std::cout << std::string(utf16_to_utf8((const std::uint16_t *)chordHeader.wszName)) << "\n";
         for (const auto& subchord : subchords) {
             std::cout << getChordName(subchord.bChordRoot) << "\n";
         }
@@ -281,8 +281,7 @@ int main(int argc, char **argv) {
         std::string styleFile = styles.front();
         styles.pop();
 
-        std::string_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
-        std::cout << "Loading style: " << utf8_conv.to_bytes(styleFile) << std::endl;
+        std::cout << "Loading style: " << styleFile << std::endl;
         auto style = ctx.loadStyle(std::string(styleFile.begin(), styleFile.end()));
         printStyle(style);
     }

--- a/utils/dmrender/src/dmrender.cpp
+++ b/utils/dmrender/src/dmrender.cpp
@@ -5,11 +5,12 @@
 #include <dmusic/InstrumentPlayer.h>
 #include <dmusic/Tracks.h>
 #include <dmusic/dls/DownloadableSound.h>
+#include <codecvt>
 
 using namespace DirectMusic;
 using namespace DirectMusic::DLS;
 
-static std::queue<std::wstring> styles;
+static std::queue<std::string> styles;
 
 class MyInstrumentPlayer : public InstrumentPlayer {
 public:
@@ -65,7 +66,7 @@ static void printBand(const BandForm& band) {
     for (const auto& instr : band.getInstruments()) {
         auto ref = instr.getReference();
         if (ref != nullptr) {
-            std::wcout << ref->getName() << " (" << ref->getFile() << ")" << ".\n";
+            std::cout << ref->getName() << " (" << ref->getFile() << ")" << ".\n";
         }
         auto header = instr.getHeader();
         // I don't know why the first bytes is skipped...
@@ -88,7 +89,7 @@ void printTrack<std::shared_ptr<ChordTrack>>(const std::shared_ptr<ChordTrack>& 
     for (const auto& chord : track->getChords()) {
         const auto& chordHeader = std::get<0>(chord);
         const auto& subchords = std::get<1>(chord);
-        std::wcout << std::wstring((const wchar_t *)chordHeader.wszName) << "\n";
+        std::cout << std::string((const wchar_t *)chordHeader.wszName) << "\n";
         for (const auto& subchord : subchords) {
             std::cout << getChordName(subchord.bChordRoot) << "\n";
         }
@@ -100,7 +101,7 @@ void printTrack<std::shared_ptr<StyleTrack>>(const std::shared_ptr<StyleTrack>& 
     for (const StyleReference& ref : track->getStyles()) {
         std::uint16_t timestamp = std::get<0>(ref);
         ReferenceList refList = std::get<1>(ref);
-        std::wcout << refList.getName() << " (" << refList.getFile() << ")" << " at " << timestamp << "\n";
+        std::cout << refList.getName() << " (" << refList.getFile() << ")" << " at " << timestamp << "\n";
         styles.push(refList.getFile());
     }
 }
@@ -277,8 +278,11 @@ int main(int argc, char **argv) {
     std::cout << "\n---\n\nLoading styles...\n";
 
     while (!styles.empty()) {
-        std::wstring styleFile = styles.front();
+        std::string styleFile = styles.front();
         styles.pop();
+
+        std::string_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
+        std::cout << "Loading style: " << utf8_conv.to_bytes(styleFile) << std::endl;
         auto style = ctx.loadStyle(std::string(styleFile.begin(), styleFile.end()));
         printStyle(style);
     }


### PR DESCRIPTION
The usage of `std::wstring` broke compatibility with non-windows systems. A crude `utf16_to_utf8` function was added. 